### PR TITLE
use utf8 as default charset if charset is set to ''

### DIFF
--- a/include/DB.inc.php
+++ b/include/DB.inc.php
@@ -110,7 +110,7 @@ class Zotero_DB {
 			'username' => $auth['user'],
 			'password' => $auth['pass'],
 			'dbname'   => $shardInfo['db'],
-			'charset'  => isset($auth['charset']) ? $auth['charset'] : 'utf8',
+			'charset'  => !empty($auth['charset']) ? $auth['charset'] : 'utf8',
 			'driver_options' => array(
 				"MYSQLI_OPT_CONNECT_TIMEOUT" => 5
 			)


### PR DESCRIPTION
$charset = '';
isset($charset) returns true