### PR TITLE
Upgrade to Elasticsearch 5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "include/Elastica"]
-	path = include/Elastica
-	url = https://github.com/ruflin/Elastica.git

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
 	"license": "AGPL-3.0",
 	"require": {
 		"aws/aws-sdk-php": "^3.2",
-		"doctrine/cache": "1.*"
+		"doctrine/cache": "1.*",
+		"elasticsearch/elasticsearch": "^5.2"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^4.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "7f2e24c78eddfaa3636ce650150f21b6",
-    "content-hash": "4df91e2f1cfeac7125942e9e4ace41d2",
+    "content-hash": "aa76ef1db3df64839675a4453f963811",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -82,7 +81,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2015-10-29 20:17:13"
+            "time": "2015-10-29T20:17:13+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -152,7 +151,62 @@
                 "cache",
                 "caching"
             ],
-            "time": "2015-10-28 11:27:45"
+            "time": "2015-10-28T11:27:45+00:00"
+        },
+        {
+            "name": "elasticsearch/elasticsearch",
+            "version": "v5.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/elastic/elasticsearch-php.git",
+                "reference": "dc57bbcd4be2c9061ebe5be59058ea8bdebc904e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/dc57bbcd4be2c9061ebe5be59058ea8bdebc904e",
+                "reference": "dc57bbcd4be2c9061ebe5be59058ea8bdebc904e",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/ringphp": "~1.0",
+                "php": "^5.6|^7.0",
+                "psr/log": "~1.0"
+            },
+            "require-dev": {
+                "cpliakas/git-wrapper": "~1.0",
+                "doctrine/inflector": "^1.1",
+                "mockery/mockery": "0.9.4",
+                "phpunit/phpunit": "^4.7|^5.4",
+                "sami/sami": "~3.2",
+                "symfony/finder": "^2.8",
+                "symfony/yaml": "^2.8"
+            },
+            "suggest": {
+                "ext-curl": "*",
+                "monolog/monolog": "Allows for client-level logging and tracing"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Elasticsearch\\": "src/Elasticsearch/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Zachary Tong"
+                }
+            ],
+            "description": "PHP Client for Elasticsearch",
+            "keywords": [
+                "client",
+                "elasticsearch",
+                "search"
+            ],
+            "time": "2017-04-12T20:40:50+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -214,7 +268,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2015-09-08 17:36:26"
+            "time": "2015-09-08T17:36:26+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -265,7 +319,7 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2015-10-15 22:28:00"
+            "time": "2015-10-15T22:28:00+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -323,7 +377,108 @@
                 "stream",
                 "uri"
             ],
-            "time": "2015-08-15 19:32:36"
+            "time": "2015-08-15T19:32:36+00:00"
+        },
+        {
+            "name": "guzzlehttp/ringphp",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/RingPHP.git",
+                "reference": "dbbb91d7f6c191e5e405e900e3102ac7f261bc0b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/dbbb91d7f6c191e5e405e900e3102ac7f261bc0b",
+                "reference": "dbbb91d7f6c191e5e405e900e3102ac7f261bc0b",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/streams": "~3.0",
+                "php": ">=5.4.0",
+                "react/promise": "~2.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "ext-curl": "Guzzle will use specific adapters if cURL is present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Ring\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
+            "time": "2015-05-20T03:37:09+00:00"
+        },
+        {
+            "name": "guzzlehttp/streams",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/streams.git",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/streams/zipball/47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple abstraction over streams of data",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "Guzzle",
+                "stream"
+            ],
+            "time": "2014-10-12T19:18:40+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",
@@ -378,7 +533,7 @@
                 "json",
                 "jsonpath"
             ],
-            "time": "2015-05-27 17:21:31"
+            "time": "2015-05-27T17:21:31+00:00"
         },
         {
             "name": "psr/http-message",
@@ -427,7 +582,100 @@
                 "request",
                 "response"
             ],
-            "time": "2015-05-04 20:22:00"
+            "time": "2015-05-04T20:22:00+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2016-10-10T12:19:37+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v2.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "62785ae604c8d69725d693eb370e1d67e94c4053"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/62785ae604c8d69725d693eb370e1d67e94c4053",
+                "reference": "62785ae604c8d69725d693eb370e1d67e94c4053",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "time": "2017-03-25T12:08:31+00:00"
         }
     ],
     "packages-dev": [
@@ -483,7 +731,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -532,7 +780,7 @@
                     "email": "mike.vanriel@naenius.com"
                 }
             ],
-            "time": "2015-02-03 12:10:50"
+            "time": "2015-02-03T12:10:50+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -592,7 +840,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2015-08-13 10:07:40"
+            "time": "2015-08-13T10:07:40+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -654,7 +902,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -701,7 +949,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2015-06-21T13:08:43+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -742,7 +990,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -783,7 +1031,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2015-06-21 08:01:12"
+            "time": "2015-06-21T08:01:12+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -832,7 +1080,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2015-09-15T10:49:45+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -904,7 +1152,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-12-12 07:45:58"
+            "time": "2015-12-12T07:45:58+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -960,7 +1208,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -1024,7 +1272,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2015-07-26T15:48:44+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1076,7 +1324,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1126,7 +1374,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2015-12-02 08:37:27"
+            "time": "2015-12-02T08:37:27+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1192,7 +1440,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-06-21 07:55:53"
+            "time": "2015-06-21T07:55:53+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1243,7 +1491,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1296,7 +1544,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2015-11-11T19:50:13+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1331,7 +1579,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -1380,7 +1628,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-12-26 13:39:53"
+            "time": "2015-12-26T13:39:53+00:00"
         }
     ],
     "aliases": [],

--- a/include/Core.inc.php
+++ b/include/Core.inc.php
@@ -28,7 +28,7 @@ class Z_Core {
 	// Set in header.php
 	public static $AWS = null; // AWS-SDK
 	public static $MC = null; // Memcached
-	public static $Elastica = null; // ElasticSearch client
+	public static $ES = null; // Elasticsearch
 	
 	// Set in config.inc.php
 	public static $debug = false;

--- a/include/header.inc.php
+++ b/include/header.inc.php
@@ -73,13 +73,6 @@ function zotero_autoload($className) {
 		require_once $className . '.inc.php';
 		return;
 	}
-	
-	// Elastica
-	if (strpos($className, 'Elastica\\') === 0) {
-		$className = str_replace('\\', '/', $className);
-		require_once 'Elastica/lib/' . $className . '.php';
-		return;
-	}
 }
 
 spl_autoload_register('zotero_autoload');
@@ -238,16 +231,11 @@ else {
 Z_Core::$AWS = new Aws\Sdk($awsConfig);
 unset($awsConfig);
 
-// Elastica
-Z_Core::$Elastica = new \Elastica\Client(array(
-	'connections' => array_map(function ($hostAndPort) {
-		preg_match('/^([^:]+)(:[0-9]+)?$/', $hostAndPort, $matches);
-		return [
-			'host' => $matches[1],
-			'port' => isset($matches[2]) ? $matches[2] : 9200
-		];
-	}, Z_CONFIG::$SEARCH_HOSTS)
-));
+// Elasticsearch
+$esConfig = [
+	'hosts' => Z_CONFIG::$SEARCH_HOSTS
+];
+Z_Core::$ES = \Elasticsearch\ClientBuilder::fromConfig($esConfig, true);
 
 require('interfaces/IAuthenticationPlugin.inc.php');
 

--- a/misc/elasticsearch/aliases.json-sample
+++ b/misc/elasticsearch/aliases.json-sample
@@ -4,7 +4,9 @@
 			"add": {
 				"alias": "item_fulltext_index_read",
 				"index": "item_fulltext_index_a"
-			},
+			}
+		},
+		{
 			"add": {
 				"alias": "item_fulltext_index_write",
 				"index": "item_fulltext_index_a"

--- a/misc/elasticsearch/item_fulltext/mapping.json
+++ b/misc/elasticsearch/item_fulltext/mapping.json
@@ -14,8 +14,7 @@
 			"enabled": false
 		},
 		"_routing": {
-			"required": true,
-			"path": "libraryID"
+			"required": true
 		},
 		"dynamic" : false
 	}

--- a/misc/elasticsearch/item_fulltext/settings.json-sample
+++ b/misc/elasticsearch/item_fulltext/settings.json-sample
@@ -1,5 +1,5 @@
 {
 	"index": {
-		"refresh_interval": "5s"
+		"refresh_interval": "1s"
 	}
 }

--- a/model/FullText.inc.php
+++ b/model/FullText.inc.php
@@ -155,7 +155,7 @@ class Zotero_FullText {
 				Zotero_DB::rollback();
 				
 				// If item key given, include that
-				$resultKey = isset($jsonObject->key) ? $jsonObject->$key : '';
+				$resultKey = isset($jsonObject->key) ? $jsonObject->key : '';
 				$results->addFailure($i, $resultKey, $e);
 			}
 			$i++;

--- a/model/FullText.inc.php
+++ b/model/FullText.inc.php
@@ -80,6 +80,7 @@ class Zotero_FullText {
 		$doc = new \Elastica\Document($id, $doc, self::$elasticsearchType);
 		$doc->setVersion($version);
 		$doc->setVersionType('external');
+		$doc->setRouting($libraryID);
 		try {
 			$response = $type->addDocument($doc);
 		}

--- a/model/FullText.inc.php
+++ b/model/FullText.inc.php
@@ -59,52 +59,33 @@ class Zotero_FullText {
 	}
 	
 	private static function indexItemInElasticsearch($libraryID, $key, $version, $timestamp, $data) {
-		$type = self::getWriteType();
-		
-		$id = $libraryID . "/" . $key;
-		$doc = [
-			'id' => $id,
-			'libraryID' => $libraryID,
-			'content' => (string) $data->content,
-			// We don't seem to be able to search on _version, so we duplicate it here
+		$params = [
+			'index' => self::$elasticsearchType . "_index_write",
+			'type' => self::$elasticsearchType,
+			'routing' => $libraryID,
+			'id' => $libraryID . "/" . $key,
+			'version_type' => 'external_gte', // Greater or equal
 			'version' => $version,
-			// Add "T" between date and time for Elasticsearch
-			'timestamp' => str_replace(" ", "T", $timestamp)
+			'body' => [
+				'libraryID' => $libraryID,
+				'content' => (string) $data->content,
+				// We don't seem to be able to search on _version, so we duplicate it here
+				'version' => $version,
+				// Add "T" between date and time for Elasticsearch
+				'timestamp' => str_replace(" ", "T", $timestamp)
+			]
 		];
+
 		foreach (self::$metadata as $prop) {
 			if (isset($data->$prop)) {
-				$doc[$prop] = (int) $data->$prop;
+				$params['body'][$prop] = (int) $data->$prop;
 			}
 		}
+
 		$start = microtime(true);
-		$doc = new \Elastica\Document($id, $doc, self::$elasticsearchType);
-		$doc->setVersion($version);
-		$doc->setVersionType('external');
-		$doc->setRouting($libraryID);
-		try {
-			$response = $type->addDocument($doc);
-		}
-		catch (Exception $e) {
-			$msg = $e->getMessage();
-			if (preg_match('/version conflict, current \[([0-9]+)\], provided \[([0-9]+)\]/', $msg, $matches)) {
-				if ($matches[1] == $matches[2]) {
-					error_log("WARNING: " . $msg);
-					return;
-				}
-			}
-			throw $e;
-		}
+		// Throws exception if version is lower. Overwrites if greater or equal
+		Z_Core::$ES->index($params);
 		StatsD::timing("elasticsearch.client.item_fulltext.add", (microtime(true) - $start) * 1000);
-		if ($response->hasError()) {
-			$msg = $response->getError();
-			if (preg_match('/version conflict, current \[([0-9]+)\], provided \[([0-9]+)\]/', $msg, $matches)) {
-				if ($matches[1] == $matches[2]) {
-					error_log("WARNING: " . $msg);
-					return;
-				}
-			}
-			throw new Exception($response->getError());
-		}
 	}
 	
 	
@@ -183,20 +164,20 @@ class Zotero_FullText {
 	 * hasn't yet been indexed
 	 */
 	public static function getItemData($libraryID, $key) {
-		$index = self::getReadIndex();
-		$type = self::getReadType();
-		$id = $libraryID . "/" . $key;
+		$params = [
+			'index' => self::$elasticsearchType . "_index_read",
+			'type' => self::$elasticsearchType,
+			'routing' => $libraryID,
+			'id' => $libraryID . "/" . $key
+		];
 		
 		try {
-			$document = $type->getDocument($id, [
-				'routing' => $libraryID
-			]);
-		}
-		catch (\Elastica\Exception\NotFoundException $e) {
+			$resp = Z_Core::$ES->get($params);
+		} catch (Elasticsearch\Common\Exceptions\Missing404Exception $e) {
 			return false;
 		}
 		
-		$esData = $document->getData();
+		$esData = $resp['_source'];
 		$itemData = array(
 			"content" => $esData['content'],
 			"version" => $esData['version'],
@@ -255,34 +236,28 @@ class Zotero_FullText {
 		}
 		
 		$maxChars = 1000000;
-		
-		$index = self::getReadIndex();
-		$type = self::getReadType();
 		$first = true;
 		$stop = false;
 		$chars = 0;
 		$data = [];
 		
 		while (($chars < $maxChars) && ($batchRows = array_splice($rows, 0, 5)) && !$stop) {
-			// Make a raw query, since Elastica doesn't yet support mget
-			$json = [
-				"docs" => []
+			$params = [
+				'index' => self::$elasticsearchType . "_index_read",
+				'type' => self::$elasticsearchType,
+				'body' => [
+					"docs" => []
+				]
 			];
 			foreach ($batchRows as $row) {
-				$json['docs'][] = [
+				$params['body']['docs'][] = [
 					"_id" => $row['libraryID'] . "/" . $row['key'],
 					"_routing" => $row['libraryID']
 				];
 			}
-			$path = $index->getName() . '/' . $type->getName() . '/_mget';
-			$response = Z_Core::$Elastica->request($path, \Elastica\Request::GET, json_encode($json));
-			if ($response->hasError()) {
-				throw new Exception($response->getError());
-			}
-			$responseData = $response->getData();
-			if (!isset($responseData['docs'])) {
-				throw new Exception("Invalid response from mget");
-			}
+			
+			$responseData = Z_Core::$ES->mget($params);
+			
 			if (sizeOf($responseData['docs']) != sizeOf($batchRows)) {
 				throw new Exception("MySQL and Elasticsearch do not match "
 					. "(" . sizeOf($responseData['docs']) . ", " . sizeOf($batchRows) . ")");
@@ -291,7 +266,7 @@ class Zotero_FullText {
 			foreach ($responseData['docs'] as $doc) {
 				list($libraryID, $key) = explode("/", $doc['_id']);
 				// This shouldn't happen
-				if (empty($doc["found"])) {
+				if (!$doc["found"]) {
 					error_log("WARNING: Item {$doc['_id']} not found in Elasticsearch");
 					continue;
 				}
@@ -337,7 +312,6 @@ class Zotero_FullText {
 				"indexedChars" => 0,
 				"totalChars" => 0,
 				"indexedPages" => 0,
-				"indexedPages" => 0,
 				"empty" => true
 			];
 		}
@@ -355,37 +329,37 @@ class Zotero_FullText {
 		// TEMP: For now, strip double-quotes and make everything a phrase search
 		$searchText = str_replace('"', '', $searchText);
 		
-		$type = self::getReadType();
-		
-		$query = new \Elastica\Query([
-			'query' => [
-				'bool' => [
-					'must' => [
-						'match_phrase' => [
-							'content' => $searchText
-						]
-					],
-					'filter' => [
-						'term' => [
-							'libraryID' => $libraryID
+		$params = [
+			'index' => self::$elasticsearchType . "_index_read",
+			'type' => self::$elasticsearchType,
+			'routing' => $libraryID,
+			"body" => [
+				'query' => [
+					'bool' => [
+						'must' => [
+							'match_phrase' => [
+								'content' => $searchText
+							]
+						],
+						'filter' => [
+							'term' => [
+								'libraryID' => $libraryID
+							]
 						]
 					]
 				]
 			]
-		]);
+		];
 		
 		$start = microtime(true);
-		$resultSet = $type->search($query, [
-			'routing' => $libraryID
-		]);
+		$resp = Z_Core::$ES->search($params);
 		StatsD::timing("elasticsearch.client.item_fulltext.search", (microtime(true) - $start) * 1000);
-		if ($resultSet->getResponse()->hasError()) {
-			throw new Exception($resultSet->getResponse()->getError());
-		}
-		$results = $resultSet->getResults();
+		
+		$results = $resp['hits']['hits'];
+		
 		$keys = array();
 		foreach ($results as $result) {
-			$keys[] = explode("/", $result->getId())[1];
+			$keys[] = explode("/", $result['_id'])[1];
 		}
 		return $keys;
 	}
@@ -413,24 +387,21 @@ class Zotero_FullText {
 	
 	public static function deleteItemContentFromElasticsearch($libraryID, $key) {
 		// Delete from Elasticsearch
-		$type = self::getWriteType();
-		
+		$params = [
+			'index' => self::$elasticsearchType . "_index_write",
+			'type' => self::$elasticsearchType,
+			'routing' => $libraryID,
+			'id' => $libraryID . "/" . $key
+		];
+
+		$start = microtime(true);
+
 		try {
-			$start = microtime(true);
-			$response = $type->deleteById($libraryID . "/" . $key, [
-				'routing' => $libraryID
-			]);
-			StatsD::timing("elasticsearch.client.item_fulltext.delete_item", (microtime(true) - $start) * 1000);
-		}
-		catch (Elastica\Exception\NotFoundException $e) {
+			Z_Core::$ES->delete($params);
+		} catch (Elasticsearch\Common\Exceptions\Missing404Exception $e) {
 			// Ignore if not found
 		}
-		catch (Exception $e) {
-			throw $e;
-		}
-		if (isset($response) && $response->hasError()) {
-			throw new Exception($response->getError());
-		}
+		StatsD::timing("elasticsearch.client.item_fulltext.delete_item", (microtime(true) - $start) * 1000);
 	}
 	
 	
@@ -441,17 +412,23 @@ class Zotero_FullText {
 		self::deleteByLibraryMySQL($libraryID);
 		
 		// Delete from Elasticsearch
-		$type = self::getWriteType();
-		
-		$libraryQuery = new \Elastica\Query\Term();
-		$libraryQuery->setTerm("libraryID", $libraryID);
-		$query = new \Elastica\Query($libraryQuery);
+		$params = [
+			'index' => self::$elasticsearchType . "_index_write",
+			'type' => self::$elasticsearchType,
+			'routing' => $libraryID,
+			'conflicts'=>'proceed',
+			'body' => [
+				'query' => [
+					'term' => [
+						'libraryID' => $libraryID
+					]
+				]
+			]
+		];
+
 		$start = microtime(true);
-		$response = $type->deleteByQuery($query);
+		Z_Core::$ES->deleteByQuery($params);
 		StatsD::timing("elasticsearch.client.item_fulltext.delete_library", (microtime(true) - $start) * 1000);
-		if ($response->hasError()) {
-			throw new Exception($response->getError());
-		}
 		
 		Zotero_DB::commit();
 	}
@@ -510,25 +487,5 @@ class Zotero_FullText {
 			$xmlNode->appendChild($doc->createTextNode($data['content']));
 		}
 		return $xmlNode;
-	}
-	
-	
-	private static function getReadIndex() {
-		return Z_Core::$Elastica->getIndex(self::$elasticsearchType . "_index_read");
-	}
-	
-	
-	private static function getWriteIndex() {
-		return Z_Core::$Elastica->getIndex(self::$elasticsearchType . "_index_write");
-	}
-	
-	
-	private static function getReadType() {
-		return new \Elastica\Type(self::getReadIndex(), self::$elasticsearchType);
-	}
-	
-	
-	private static function getWriteType() {
-		return new \Elastica\Type(self::getWriteIndex(), self::$elasticsearchType);
 	}
 }


### PR DESCRIPTION
We should, probably, drop Elastica and move to elasticsearch-php, which is official library. Elastica adds unnecessary code layer that is poorly documented. If we are going to move to Elasticsearch or add more features, we should write queries in Elasticsearch DSL. It's simpler and well documented on Elasticsearch web. We could just read ES docs and directly write queries in DSL in PHP and skip the undocumented Elastica docs :)

This pull request is enough for zotero-server to pass tests, but isn't reviewed enough if all queries are behaving correctly. We need to decide if we want to rewrite to DSL.

Elasticsearch 5 also needs the newest Elastica, which also needs more dependencies:
composer require psr/log:dev-master
composer require elasticsearch/elasticsearch