### PR TITLE
Keep fulltext data in S3 instead of Elasticsearch

### DIFF
--- a/include/config/config.inc.php-sample
+++ b/include/config/config.inc.php-sample
@@ -25,7 +25,8 @@ class Z_CONFIG {
 	public static $AWS_SECRET_KEY = '';
 	public static $S3_BUCKET = '';
 	public static $S3_BUCKET_CACHE = '';
-	
+	public static $S3_BUCKET_FULLTEXT = '';
+
 	public static $REDIS_HOSTS = [
 		'default' => 'redis1.localdomain',
 		'request-limiter' => => 'redis-transient.localdomain',

--- a/include/config/config.inc.php-sample
+++ b/include/config/config.inc.php-sample
@@ -31,6 +31,7 @@ class Z_CONFIG {
 		'default' => 'redis1.localdomain',
 		'request-limiter' => => 'redis-transient.localdomain',
 		'notifications' => 'redis-transient.localdomain'
+		'fulltext-migration' => 'redis-transient.localdomain'
 	];
 	public static $REDIS_PREFIX = '';
 	

--- a/model/FullText.inc.php
+++ b/model/FullText.inc.php
@@ -83,8 +83,7 @@ class Zotero_FullText {
 		
 		// Todo: Remove fall back code after migration
 		$redisClient = new Redis();
-		$redisClient->connect('localhost');
-		$redisClient->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_IGBINARY);
+		$redisClient->pconnect('localhost');
 		$redisClient->set('s3:' . $libraryID . "/" . $key, '1');
 	}
 	


### PR DESCRIPTION
**Edit:**
**The actual ES to S3 import script: [es-to-s3](https://github.com/mrtcode/es-to-s3)**
**Lambda function to continuously index fulltext data from S3 to ES: [s3-lambda-es](https://github.com/mrtcode/s3-lambda-es)**

---

Turns out that many FullText functions are already inside transactions. I started moving out S3 code outside of transactions, but significant rewrites are need which can introduce new problems. Maybe we should postpone this after we clean up the classical sync code. Now I just made as simple as possible and just replaced ES code with S3. I guess ES queries wasn't super fast either.

For example those FullText function are inside transactions:
https://github.com/mrtcode/dataserver/blob/18a93e751e062876d4a9fb2dd259ebc14b7a8de9/controllers/FullTextController.php#L135-L135

https://github.com/mrtcode/dataserver/blob/6e66889eae736b5dfd0521f6c2aa3514af56d532/model/Sync.inc.php#L1401-L1401

https://github.com/mrtcode/dataserver/blob/2a60582450a5702365645022ddc6fe4fe40f84f9/model/DataObjects.inc.php#L628-L628


Also S3 request is already used inside another transaction in duplicateFile:
https://github.com/mrtcode/dataserver/blob/805536ad276c772ecf0d8205e1e20a96ea97e0cb/controllers/ItemsController.php#L925-L925
