### PR TITLE
Remove filename from storageFiles

### DIFF
--- a/controllers/ItemsController.php
+++ b/controllers/ItemsController.php
@@ -961,7 +961,7 @@ class ItemsController extends ApiController {
 				Zotero_DB::query("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE");
 				Zotero_DB::beginTransaction();
 				
-				// See if file exists with this hash and zip flag
+				// See if file exists with this hash
 				$localInfo = Zotero_Storage::getLocalFileInfo($info);
 				if ($localInfo) {
 					$storageFileID = $localInfo['storageFileID'];

--- a/model/Attachments.inc.php
+++ b/model/Attachments.inc.php
@@ -66,7 +66,6 @@ class Zotero_Attachments {
 		
 		$info = Zotero_Storage::getLocalFileItemInfo($item);
 		$storageFileID = $info['storageFileID'];
-		$filename = $info['filename'];
 		$mtime = $info['mtime'];
 		$zip = $info['zip'];
 		$realFilename = preg_replace("/^storage:/", "", $item->attachmentPath);
@@ -188,16 +187,17 @@ class Zotero_Attachments {
 		if (!mkdir($downloadDir, 0777, true)) {
 			throw new Exception("Unable to create directory '$downloadDir'");
 		}
+		$archiveFilename = 'archive.zip';
 		if ($zip) {
-			$response = Zotero_Storage::downloadFile($info, $downloadDir, '1.zip');
+			$response = Zotero_Storage::downloadFile($info, $downloadDir, $archiveFilename);
 		}
 		else {
 			$response = Zotero_Storage::downloadFile($info, $downloadDir, $realFilename);
 		}
 		if ($response) {
 			if ($zip) {
-				$success = self::extractZip($downloadDir . '1.zip', $dir);
-				unlink($downloadDir . '1.zip');
+				$success = self::extractZip($downloadDir . $archiveFilename, $dir);
+				unlink($downloadDir . $archiveFilename);
 				rmdir($downloadDir);
 				
 				// Make sure charset is just a string with no spaces or newlines

--- a/model/Attachments.inc.php
+++ b/model/Attachments.inc.php
@@ -189,15 +189,15 @@ class Zotero_Attachments {
 			throw new Exception("Unable to create directory '$downloadDir'");
 		}
 		if ($zip) {
-			$response = Zotero_Storage::downloadFile($info, $downloadDir);
+			$response = Zotero_Storage::downloadFile($info, $downloadDir, '1.zip');
 		}
 		else {
 			$response = Zotero_Storage::downloadFile($info, $downloadDir, $realFilename);
 		}
 		if ($response) {
 			if ($zip) {
-				$success = self::extractZip($downloadDir . $info['filename'], $dir);
-				unlink($downloadDir . $info['filename']);
+				$success = self::extractZip($downloadDir . '1.zip', $dir);
+				unlink($downloadDir . '1.zip');
 				rmdir($downloadDir);
 				
 				// Make sure charset is just a string with no spaces or newlines

--- a/model/Storage.inc.php
+++ b/model/Storage.inc.php
@@ -188,7 +188,7 @@ class Zotero_Storage {
 		$size = $info['size'];
 		
 		$sql = "INSERT INTO storageDownloadLog
-				(ownerUserID, downloadUserID, ipAddress, storageFileID, size)
+				(ownerUserID, downloadUserID, ipAddress, storageFileID, `size`)
 				VALUES (?, ?, INET_ATON(?), ?, ?)";
 		Zotero_DB::query(
 			$sql,
@@ -480,7 +480,9 @@ class Zotero_Storage {
 		return self::addFile($info);
 	}
 	
-	
+	// TODO: Remove
+	// Was previously used in ItemController to find a file with a different name,
+	// if not found with the given filename. Now getLocalFileInfo does the same.
 	public static function getFileByHash($hash, $zip) {
 		$sql = "SELECT storageFileID FROM storageFiles WHERE hash=? AND zip=? LIMIT 1";
 		return Zotero_DB::valueQuery($sql, array($hash, (int) $zip));
@@ -493,7 +495,7 @@ class Zotero_Storage {
 	
 	public static function getLocalFileInfo(Zotero_StorageFileInfo $info) {
 		$sql = "SELECT * FROM storageFiles WHERE hash=? AND zip=? ORDER BY storageFileID LIMIT 1";
-		return Zotero_DB::rowQuery($sql, array($info->hash, (int)$info->zip));
+		return Zotero_DB::rowQuery($sql, array($info->hash, (int) $info->zip));
 	}
 	
 	public static function getRemoteFileInfo(Zotero_StorageFileInfo $info) {
@@ -575,7 +577,7 @@ class Zotero_Storage {
 	
 	public static function addFile(Zotero_StorageFileInfo $info) {
 		$sql = "INSERT INTO storageFiles (hash, `size`, zip) VALUES (?,?,?)";
-		return Zotero_DB::query($sql, array($info->hash, $info->size, (int)$info->zip));
+		return Zotero_DB::query($sql, array($info->hash, $info->size, (int) $info->zip));
 	}
 	
 	


### PR DESCRIPTION
'filename' column should be removed from storageDownloadLog and storageUploadLog too, because they depend on storageFiles table.

For those tables a default 'filename' value must be set.
storageFiles
storageDownloadLog
storageUploadLog