### PR TITLE
File identifier

### DIFF
--- a/controllers/StorageController.php
+++ b/controllers/StorageController.php
@@ -164,4 +164,67 @@ class StorageController extends ApiController {
 		Zotero_Storage::transferBucket('zoterofilestorage', 'zoterofilestoragetest');
 		exit;
 	}
+	
+	public function identify() {
+		$this->allowMethods(array('POST'));
+		
+		// 10 requests per second per IP with 100 requests burst
+		$rateLimit = [
+			'logOnly' => false,
+			'bucket' => $_SERVER['REMOTE_ADDR'],
+			'capacity' => 100,
+			'rate' => 10
+		];
+		
+		// $this->requestLimiter must be initialized in ApiController
+		$requestsRemaining = $this->requestLimiter->checkBucketRate($rateLimit);
+		
+		if (!$requestsRemaining) {
+			StatsD::increment("request.limit.identify.rate.rejected", 1);
+			Z_Core::logError('Request rate limit exceeded for' . $rateLimit['bucket']);
+			
+			if (!$rateLimit['logOnly']) {
+				header("Retry-After: " . (int)$rateLimit['capacity'] / $rateLimit['rate']);
+				$this->e429();
+			}
+		}
+		
+		if (!empty($_REQUEST['hash'])) {
+			$hash = $_REQUEST['hash'];
+			$fieldTypes = [
+				11, // ISBN
+				13, // ISSN
+				26 // DOI
+			];
+			$identifiers = [];
+			
+			// Returns up to 10 identifiers and checks up to 5 libraries
+			$numIdentifiers = 0;
+			$numLibraries = 0;
+			
+			$libraryIDs = Zotero_Storage::getHashLibraries($hash);
+			while (($libraryID = array_shift($libraryIDs))
+				&& $numIdentifiers < 10
+				&& $numLibraries++ < 5) {
+				$fields = Zotero_Storage::getFileSourceFields($libraryID, $hash, $fieldTypes);
+				foreach ($fields as $fieldID => $values) {
+					$fieldName = Zotero_ItemFields::getName($fieldID);
+					foreach ($values as $value) {
+						if (!isset($identifiers[$fieldName])) {
+							$identifiers[$fieldName] = [];
+						}
+						
+						if (!in_array($value, $identifiers[$fieldName])) {
+							$identifiers[$fieldName][] = $value;
+							$numIdentifiers++;
+						}
+					}
+				}
+			}
+			
+			echo Zotero_Utilities::formatJSON([
+				'identifiers' => $identifiers
+			]);
+		}
+	}
 }

--- a/include/config/routes.inc.php
+++ b/include/config/routes.inc.php
@@ -34,6 +34,7 @@ else {
 	$router->map('/users/i:objectUserID/publications/items/:objectKey/file/view', ['controller' => 'Items', 'extra' => ['allowHTTP' => true, 'file' => true, 'view' => true, 'publications' => true]]);
 	$router->map('/groups/i:objectGroupID/items/:objectKey/file', array('controller' => 'Items', 'extra' => array('allowHTTP' => true, 'file' => true)));
 	$router->map('/groups/i:objectGroupID/items/:objectKey/file/view', array('controller' => 'Items', 'extra' => array('allowHTTP' => true, 'file' => true, 'view' => true)));
+	$router->map('/identify', array('controller' => 'Storage', 'action' => 'identify'));
 	
 	// Full-text content
 	$router->map('/users/i:objectUserID/items/:objectKey/fulltext', array('controller' => 'FullText', 'action' => 'itemContent'));


### PR DESCRIPTION
A prototype of file identifier. Currently supports identifying files by hash.

File item itself doesn't have file metadata. Instead, itemAttachments table is required to resolve sourceItemID and the actual items that have file metadata. itemAttachments also has storageHash column which - for simplicity reasons - is used in this prototype to query required items. But it needs to create an index. Another option is to query through storageFileItems table with storafeFileID.

This prototype is querying by library.

Because file item can be nested to any other item, this can result in incorrect metadata. Therefore more libraries should be used to evaluate results. But probably no need to scan too many libraries.

Looking in future, maybe the file identifier should have its own controller if it's going to use full text data. E.g.: IdentifierController.

It's probably convenient to use specific rate limiters in different controllers than the global rate limiter in ApiController.

The result looks like:

```
{
    "identifiers": {
        "ISSN": [
            "1935-990X, 0003-066X"
        ],
        "DOI": [
            "10.1037/0003-066X.59.1.29"
        ]
    }
}
```

