### PR TITLE
Global Items API

### DIFF
--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -44,6 +44,7 @@ class ApiController extends Controller {
 	protected $objectUserID; // userID of object owner
 	protected $objectGroupID; // groupID of object owner
 	protected $objectLibraryID; // libraryID of object owner
+	protected $objectGlobalItemID;
 	protected $scopeObject;
 	protected $scopeObjectID;
 	protected $scopeObjectKey;

--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -54,7 +54,6 @@ class ApiController extends Controller {
 	protected $objectName;
 	protected $subset;
 	protected $singleObject;
-	protected $globalItems = false;
 	protected $publications = false;
 	protected $legacyPublications = false;
 	protected $fileMode;
@@ -346,10 +345,6 @@ class ApiController extends Controller {
 		if (!$apiVersion && !empty($_SERVER['HTTP_USER_AGENT'])
 				&& strpos($_SERVER['HTTP_USER_AGENT'], 'ZotPad 1') === 0) {
 			$apiVersion = 1;
-		}
-		
-		if (!empty($extra['globalItems'])) {
-			$this->globalItems = true;
 		}
 		
 		if (!empty($extra['publications'])) {

--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -53,6 +53,7 @@ class ApiController extends Controller {
 	protected $objectName;
 	protected $subset;
 	protected $singleObject;
+	protected $globalItems = false;
 	protected $publications = false;
 	protected $legacyPublications = false;
 	protected $fileMode;
@@ -344,6 +345,10 @@ class ApiController extends Controller {
 		if (!$apiVersion && !empty($_SERVER['HTTP_USER_AGENT'])
 				&& strpos($_SERVER['HTTP_USER_AGENT'], 'ZotPad 1') === 0) {
 			$apiVersion = 1;
+		}
+		
+		if (!empty($extra['globalItems'])) {
+			$this->globalItems = true;
 		}
 		
 		if (!empty($extra['publications'])) {

--- a/controllers/GlobalItemsController.php
+++ b/controllers/GlobalItemsController.php
@@ -27,72 +27,36 @@
 require('ApiController.php');
 
 class GlobalItemsController extends ApiController {
-	// Elastic search has a default 'index.max_result_window=10000' limit,
-	// therefore start+limit can not be more than 10000
-	const maxResultWindow = 10000;
-	const endpointTimeout = 3; // In seconds
 	
 	public function globalItems() {
 		$this->allowMethods(array('GET'));
 		
-		$start = $this->queryParams['start'];
-		$limit = $this->queryParams['limit'];
-		if ($start + $limit > self::maxResultWindow) {
-			$this->e400("Maximum result window exceeded");
-		}
-		
-		$requestURL = Z_CONFIG::$GLOBAL_ITEMS_ENDPOINT;
-		if ($requestURL[strlen($requestURL) - 1] != "/") {
-			$requestURL .= "/";
-		}
-		$requestURL .= 'global/items';
-		
+		$params = [];
 		if (!empty($_GET['q'])) {
-			$q = $_GET['q'];
-			if (strlen($q) < 3) {
+			if (strlen($_GET['q']) < 3) {
 				$this->e400("Query string must be at least 3 characters length");
 			}
-			$requestURL .= '?q=' . rawurlencode($q);
+			$params['q'] = $_GET['q'];
 		}
 		else if (!empty($_GET['doi'])) {
-			$doi = $_GET['doi'];
-			$requestURL .= '?doi=' . rawurlencode($doi);
+			$params['doi'] = $_GET['doi'];
 		}
 		else if (!empty($_GET['isbn'])) {
-			$isbn = $_GET['isbn'];
-			$requestURL .= '?isbn=' . rawurlencode($isbn);
+			$params['isbn'] = $_GET['isbn'];
 		}
 		else if (!empty($_GET['url'])) {
-			$url = $_GET['url'];
-			$requestURL .= '?url=' . rawurlencode($url);
+			$params['url'] = $_GET['url'];
 		}
 		else {
-			$this->e400("One of these prameters must be set: q, doi, isbn, url");
+			$this->e400("One of these parameters must be set: q, doi, isbn, url");
 		}
 		
-		$requestURL .= '&start=' . $start . '&limit=' . $limit;
-
-		$start = microtime(true);
+		$params['start'] = $this->queryParams['start'];
+		$params['limit'] = $this->queryParams['limit'];
 		
-		$ch = curl_init($requestURL);
-		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 1);
-		curl_setopt($ch, CURLOPT_TIMEOUT, self::endpointTimeout);
-		curl_setopt($ch, CURLOPT_HEADER, 0); // do not return HTTP headers
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-		// Allow an invalid ssl certificate (Todo: remove)
-		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
-		$response = curl_exec($ch);
+		$response = Zotero_GlobalItems::getGlobalItems($params);
 		
-		$time = microtime(true) - $start;
-		StatsD::timing("api.globalitems", $time * 1000);
-		
-		$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-		
-		if ($code != 200) {
-			$response = null;
-			Z_Core::logError("HTTP $code from Global Items API $requestURL");
-			Z_Core::logError($response);
+		if (!$response) {
 			$this->e500("Endpoint error");
 		}
 		

--- a/controllers/GlobalItemsController.php
+++ b/controllers/GlobalItemsController.php
@@ -27,7 +27,6 @@
 require('ApiController.php');
 
 class GlobalItemsController extends ApiController {
-	
 	public function globalItems() {
 		$this->allowMethods(['GET']);
 		$params = [];
@@ -54,38 +53,14 @@ class GlobalItemsController extends ApiController {
 		$params['limit'] = $this->queryParams['limit'];
 		
 		$result = Zotero_GlobalItems::getGlobalItems($params);
-		
-		$thresholdMonthTime = mktime(0, 0, 0, date('m') - 12, 1, date('Y'));
 		for ($i = 0, $len = sizeOf($result['data']); $i < $len; $i++) {
-			$datesAdded = [];
 			unset($result['data'][$i]['libraryItems']);
 			unset($result['data'][$i]['meta']['instanceCount']);
-			$len2 = sizeOf($result['data'][$i]['meta']['datesAdded']);
-			for ($j = 0; $j < $len2; $j++) {
-				$dateAdded = $result['data'][$i]['meta']['datesAdded'][$j];
-				$addedMonthTime = strtotime($dateAdded['month']);
-				if ($addedMonthTime >= $thresholdMonthTime) {
-					$datesAdded[] = $result['data'][$i]['meta']['datesAdded'][$j];
-				}
-			}
-			$result['data'][$i]['meta']['datesAdded'] = $datesAdded;
 		}
 		
 		header('Content-Type: application/json');
 		header('Total-Results: ' . $result['totalResults']);
 		echo Zotero_Utilities::formatJSON($result['data']);
-		$this->end();
-	}
-	
-	public function added() {
-		$this->allowMethods(['GET']);
-		$id = $this->objectGlobalItemID;
-		$datesAdded = Zotero_GlobalItems::getGlobalItemDatesAdded($id);
-		if (!$datesAdded) {
-			$this->e404();
-		}
-		header('Content-Type: application/json');
-		echo Zotero_Utilities::formatJSON($datesAdded);
 		$this->end();
 	}
 }

--- a/controllers/GlobalItemsController.php
+++ b/controllers/GlobalItemsController.php
@@ -57,16 +57,18 @@ class GlobalItemsController extends ApiController {
 		
 		$thresholdMonthTime = mktime(0, 0, 0, date('m') - 12, 1, date('Y'));
 		for ($i = 0, $len = sizeOf($result['data']); $i < $len; $i++) {
+			$datesAdded = [];
 			unset($result['data'][$i]['libraryItems']);
 			unset($result['data'][$i]['meta']['instanceCount']);
 			$len2 = sizeOf($result['data'][$i]['meta']['datesAdded']);
 			for ($j = 0; $j < $len2; $j++) {
 				$dateAdded = $result['data'][$i]['meta']['datesAdded'][$j];
 				$addedMonthTime = strtotime($dateAdded['month']);
-				if ($addedMonthTime < $thresholdMonthTime) {
-					unset($result['data'][$i]['meta']['datesAdded'][$j]);
+				if ($addedMonthTime >= $thresholdMonthTime) {
+					$datesAdded[] = $result['data'][$i]['meta']['datesAdded'][$j];
 				}
 			}
+			$result['data'][$i]['meta']['datesAdded'] = $datesAdded;
 		}
 		
 		header('Content-Type: application/json');

--- a/controllers/GlobalItemsController.php
+++ b/controllers/GlobalItemsController.php
@@ -1,0 +1,88 @@
+<?php
+/*
+    ***** BEGIN LICENSE BLOCK *****
+
+    This file is part of the Zotero Data Server.
+
+    Copyright © 2017 Center for History and New Media
+                     George Mason University, Fairfax, Virginia, USA
+                     http://zotero.org
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    ***** END LICENSE BLOCK *****
+*/
+
+require('ApiController.php');
+
+class GlobalItemsController extends ApiController {
+	// Elastic search has a default 'index.max_result_window=10000' limit,
+	// therefore start+limit can not be more than 10000
+	const maxResultWindow = 10000;
+	const endpointTimeout = 3; // In seconds
+	
+	public function globalItems() {
+		$this->allowMethods(array('GET'));
+		
+		if (empty($this->queryParams['q'])) {
+			$this->e400("Query parameter must be set");
+		}
+		$query = $this->queryParams['q'];
+		
+		if (strlen($query) < 3) {
+			$this->e400("Query string must be at least 3 character length");
+		}
+		
+		$start = $this->queryParams['start'];
+		$limit = $this->queryParams['limit'];
+		
+		if ($start + $limit > self::maxResultWindow) {
+			$this->e400("Maximum result window exceeded");
+		}
+		
+		$requestURL = Z_CONFIG::$GLOBAL_ITEMS_ENDPOINT;
+		if ($requestURL[strlen($requestURL) - 1] != "/") {
+			$requestURL .= "/";
+		}
+		$requestURL .= 'global/items?q=' . urlencode($query)
+			. '&start=' . $start . '&limit=' . $limit;
+		
+		$start = microtime(true);
+		
+		$ch = curl_init($requestURL);
+		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 1);
+		curl_setopt($ch, CURLOPT_TIMEOUT, self::endpointTimeout);
+		curl_setopt($ch, CURLOPT_HEADER, 0); // do not return HTTP headers
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+		// Allow an invalid ssl certificate (Todo: remove)
+		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
+		$response = curl_exec($ch);
+		
+		$time = microtime(true) - $start;
+		StatsD::timing("api.globalitems", $time * 1000);
+		
+		$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+		
+		if ($code != 200) {
+			$response = null;
+			Z_Core::logError("HTTP $code from Global Items API $requestURL");
+			Z_Core::logError($response);
+			$this->e500("Endpoint error");
+		}
+		
+		header("Content-Type: application/json");
+		echo $response;
+	}
+}

--- a/controllers/GlobalItemsController.php
+++ b/controllers/GlobalItemsController.php
@@ -70,7 +70,7 @@ class GlobalItemsController extends ApiController {
 		}
 		
 		header('Content-Type: application/json');
-		header('Total-Results:' . $result['totalResults']);
+		header('Total-Results: ' . $result['totalResults']);
 		echo Zotero_Utilities::formatJSON($result['data']);
 		$this->end();
 	}
@@ -79,6 +79,10 @@ class GlobalItemsController extends ApiController {
 		$this->allowMethods(['GET']);
 		$id = $this->objectGlobalItemID;
 		$datesAdded = Zotero_GlobalItems::getGlobalItemDatesAdded($id);
+		if (!$datesAdded) {
+			$this->e404();
+		}
+		header('Content-Type: application/json');
 		echo Zotero_Utilities::formatJSON($datesAdded);
 		$this->end();
 	}

--- a/controllers/GlobalItemsController.php
+++ b/controllers/GlobalItemsController.php
@@ -35,18 +35,8 @@ class GlobalItemsController extends ApiController {
 	public function globalItems() {
 		$this->allowMethods(array('GET'));
 		
-		if (empty($this->queryParams['q'])) {
-			$this->e400("Query parameter must be set");
-		}
-		$query = $this->queryParams['q'];
-		
-		if (strlen($query) < 3) {
-			$this->e400("Query string must be at least 3 character length");
-		}
-		
 		$start = $this->queryParams['start'];
 		$limit = $this->queryParams['limit'];
-		
 		if ($start + $limit > self::maxResultWindow) {
 			$this->e400("Maximum result window exceeded");
 		}
@@ -55,9 +45,33 @@ class GlobalItemsController extends ApiController {
 		if ($requestURL[strlen($requestURL) - 1] != "/") {
 			$requestURL .= "/";
 		}
-		$requestURL .= 'global/items?q=' . urlencode($query)
-			. '&start=' . $start . '&limit=' . $limit;
+		$requestURL .= 'global/items';
 		
+		if (!empty($_GET['q'])) {
+			$q = $_GET['q'];
+			if (strlen($q) < 3) {
+				$this->e400("Query string must be at least 3 characters length");
+			}
+			$requestURL .= '?q=' . rawurlencode($q);
+		}
+		else if (!empty($_GET['doi'])) {
+			$doi = $_GET['doi'];
+			$requestURL .= '?doi=' . rawurlencode($doi);
+		}
+		else if (!empty($_GET['isbn'])) {
+			$isbn = $_GET['isbn'];
+			$requestURL .= '?isbn=' . rawurlencode($isbn);
+		}
+		else if (!empty($_GET['url'])) {
+			$url = $_GET['url'];
+			$requestURL .= '?url=' . rawurlencode($url);
+		}
+		else {
+			$this->e400("One of these prameters must be set: q, doi, isbn, url");
+		}
+		
+		$requestURL .= '&start=' . $start . '&limit=' . $limit;
+
 		$start = microtime(true);
 		
 		$ch = curl_init($requestURL);

--- a/controllers/GlobalItemsController.php
+++ b/controllers/GlobalItemsController.php
@@ -30,7 +30,6 @@ class GlobalItemsController extends ApiController {
 	
 	public function globalItems() {
 		$this->allowMethods(array('GET'));
-		
 		$params = [];
 		if (!empty($_GET['q'])) {
 			if (strlen($_GET['q']) < 3) {
@@ -48,18 +47,13 @@ class GlobalItemsController extends ApiController {
 			$params['url'] = $_GET['url'];
 		}
 		else {
-			$this->e400("One of these parameters must be set: q, doi, isbn, url");
+			$this->e400("One of the query parameters must be used: q, doi, isbn, url");
 		}
 		
 		$params['start'] = $this->queryParams['start'];
 		$params['limit'] = $this->queryParams['limit'];
 		
 		$response = Zotero_GlobalItems::getGlobalItems($params);
-		
-		if (!$response) {
-			$this->e500("Endpoint error");
-		}
-		
 		header("Content-Type: application/json");
 		echo $response;
 	}

--- a/controllers/ItemsController.php
+++ b/controllers/ItemsController.php
@@ -55,6 +55,9 @@ class ItemsController extends ApiController {
 		if ($this->objectGlobalItemID) {
 			$id = $this->objectGlobalItemID;
 			$libraryItems = Zotero_GlobalItems::getGlobalItemLibraryItems($id);
+			if (!$libraryItems) {
+				$this->e404();
+			}
 			// TODO: Improve pagination
 			// Pagination isn't reliable here, because we
 			// don't know if library and key exist and if we have permissions

--- a/controllers/ItemsController.php
+++ b/controllers/ItemsController.php
@@ -52,7 +52,7 @@ class ItemsController extends ApiController {
 		$results = array();
 		$title = "";
 		
-		if ($this->globalItems) {
+		if ($this->objectGlobalItemID) {
 			$id = $this->objectGlobalItemID;
 			$libraryItems = Zotero_GlobalItems::getGlobalItemLibraryItems($id);
 			// TODO: Improve pagination
@@ -68,7 +68,7 @@ class ItemsController extends ApiController {
 			// Group items by libraryID to later query all library's items at once
 			$groupedLibraryItems = [];
 			for ($i = 0, $len = sizeOf($libraryItems); $i < $len; $i++) {
-				list($libraryID, $key) = explode('/', $libraryItems[$i]);
+				list($libraryID, $key) = $libraryItems[$i];
 				$groupedLibraryItems[$libraryID][] = $key;
 			}
 			
@@ -78,11 +78,9 @@ class ItemsController extends ApiController {
 					continue;
 				}
 				// Do not pass $this->queryParams directly to prevent
-				// other query parameters influencing Zotero_Items::search
+				// other query parameters from influencing Zotero_Items::search
 				$params = [
 					'format' => $this->queryParams['format'],
-					// Throws exception if 'publications' parameter isn't set
-					'publications' => false,
 					'itemKey' => $keys
 				];
 				$results = Zotero_Items::search(
@@ -92,7 +90,7 @@ class ItemsController extends ApiController {
 				);
 				$allResults = array_merge($allResults, $results);
 			}
-			$this->generateMultiResponse($allResults, $title);
+			$this->generateMultiResponse($allResults);
 			$this->end();
 		}
 		

--- a/include/config/config.inc.php-sample
+++ b/include/config/config.inc.php-sample
@@ -47,7 +47,9 @@ class Z_CONFIG {
 	public static $SEARCH_HOSTS = [''];
 	
 	public static $SNS_TOPIC_STREAM_EVENTS = 'arn:aws:sns:...';
-	
+
+	public static $GLOBAL_ITEMS_ENDPOINT = '';
+
 	public static $ATTACHMENT_SERVER_HOSTS = array("files1.localdomain", "files2.localdomain");
 	public static $ATTACHMENT_SERVER_DYNAMIC_PORT = 80;
 	public static $ATTACHMENT_SERVER_STATIC_PORT = 81;

--- a/include/config/config.inc.php-sample
+++ b/include/config/config.inc.php-sample
@@ -48,7 +48,7 @@ class Z_CONFIG {
 	
 	public static $SNS_TOPIC_STREAM_EVENTS = 'arn:aws:sns:...';
 
-	public static $GLOBAL_ITEMS_ENDPOINT = '';
+	public static $GLOBAL_ITEMS_URL = '';
 
 	public static $ATTACHMENT_SERVER_HOSTS = array("files1.localdomain", "files2.localdomain");
 	public static $ATTACHMENT_SERVER_DYNAMIC_PORT = 80;

--- a/include/config/routes.inc.php
+++ b/include/config/routes.inc.php
@@ -15,6 +15,8 @@ else {
 	
 	$router->map('/items', array('controller' => 'GlobalItems'));
 	
+	$router->map('/items/libraryitems', ['controller' => 'Items', 'extra' => ['globalItems' => true]]);
+	
 	// Groups
 	$router->map('/groups/i:objectGroupID', array('controller' => 'Groups'));
 	$router->map('/groups/i:scopeObjectID/users/i:objectID', array('controller' => 'Groups', 'action' => 'groupUsers'));

--- a/include/config/routes.inc.php
+++ b/include/config/routes.inc.php
@@ -13,6 +13,8 @@ if ($_SERVER['HTTP_HOST'] == Z_CONFIG::$SYNC_DOMAIN) {
 else {
 	$router->map('/', array('controller' => 'Api', 'action' => 'noop', 'extra' => array('allowHTTP' => true)));
 	
+	$router->map('/items', array('controller' => 'GlobalItems'));
+	
 	// Groups
 	$router->map('/groups/i:objectGroupID', array('controller' => 'Groups'));
 	$router->map('/groups/i:scopeObjectID/users/i:objectID', array('controller' => 'Groups', 'action' => 'groupUsers'));

--- a/include/config/routes.inc.php
+++ b/include/config/routes.inc.php
@@ -14,8 +14,7 @@ else {
 	$router->map('/', array('controller' => 'Api', 'action' => 'noop', 'extra' => array('allowHTTP' => true)));
 	
 	$router->map('/items', array('controller' => 'GlobalItems'));
-	
-	$router->map('/items/libraryitems', ['controller' => 'Items', 'extra' => ['globalItems' => true]]);
+	$router->map('/items/:objectGlobalItemID/libraryitems', ['controller' => 'Items', 'extra' => ['globalItems' => true]]);
 	
 	// Groups
 	$router->map('/groups/i:objectGroupID', array('controller' => 'Groups'));

--- a/include/config/routes.inc.php
+++ b/include/config/routes.inc.php
@@ -13,8 +13,9 @@ if ($_SERVER['HTTP_HOST'] == Z_CONFIG::$SYNC_DOMAIN) {
 else {
 	$router->map('/', array('controller' => 'Api', 'action' => 'noop', 'extra' => array('allowHTTP' => true)));
 	
-	$router->map('/items', array('controller' => 'GlobalItems'));
-	$router->map('/items/:objectGlobalItemID/libraryitems', ['controller' => 'Items', 'extra' => ['globalItems' => true]]);
+	$router->map('/items', ['controller' => 'GlobalItems']);
+	$router->map('/items/:objectGlobalItemID/added', ['controller' => 'GlobalItems', 'action' => 'added']);
+	$router->map('/items/:objectGlobalItemID/libraryitems', ['controller' => 'Items']);
 	
 	// Groups
 	$router->map('/groups/i:objectGroupID', array('controller' => 'Groups'));

--- a/include/config/routes.inc.php
+++ b/include/config/routes.inc.php
@@ -14,7 +14,6 @@ else {
 	$router->map('/', array('controller' => 'Api', 'action' => 'noop', 'extra' => array('allowHTTP' => true)));
 	
 	$router->map('/items', ['controller' => 'GlobalItems']);
-	$router->map('/items/:objectGlobalItemID/added', ['controller' => 'GlobalItems', 'action' => 'added']);
 	$router->map('/items/:objectGlobalItemID/libraryitems', ['controller' => 'Items']);
 	
 	// Groups

--- a/model/GlobalItems.inc.php
+++ b/model/GlobalItems.inc.php
@@ -1,0 +1,126 @@
+<?php
+/*
+    ***** BEGIN LICENSE BLOCK *****
+    
+    This file is part of the Zotero Data Server.
+    
+    Copyright © 2017 Center for History and New Media
+                     George Mason University, Fairfax, Virginia, USA
+                     http://zotero.org
+    
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    
+    ***** END LICENSE BLOCK *****
+*/
+
+class Zotero_GlobalItems {
+	const endpointTimeout = 3;
+	
+	public static function getGlobalItems($params) {
+		
+		$requestURL = Z_CONFIG::$GLOBAL_ITEMS_ENDPOINT;
+		if ($requestURL[strlen($requestURL) - 1] != "/") {
+			$requestURL .= "/";
+		}
+		$requestURL .= 'global/items';
+		
+		if (!empty($params['q'])) {
+			$q = $params['q'];
+			$requestURL .= '?q=' . rawurlencode($q);
+		}
+		else if (!empty($params['doi'])) {
+			$doi = $params['doi'];
+			$requestURL .= '?doi=' . rawurlencode($doi);
+		}
+		else if (!empty($params['isbn'])) {
+			$isbn = $params['isbn'];
+			$requestURL .= '?isbn=' . rawurlencode($isbn);
+		}
+		else if (!empty($params['url'])) {
+			$url = $params['url'];
+			$requestURL .= '?url=' . rawurlencode($url);
+		}
+		else {
+			return false;
+		}
+		
+		if (!empty($params['start'])) {
+			$requestURL .= '&start=' . $params['start'];
+		}
+		
+		if (!empty($params['limit'])) {
+			$requestURL .= '&limit=' . $params['limit'];
+		}
+		
+		$start = microtime(true);
+		
+		$ch = curl_init($requestURL);
+		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 1);
+		curl_setopt($ch, CURLOPT_TIMEOUT, self::endpointTimeout);
+		curl_setopt($ch, CURLOPT_HEADER, 0); // do not return HTTP headers
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+		// Allow an invalid ssl certificate (Todo: remove)
+		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
+		$response = curl_exec($ch);
+		
+		$time = microtime(true) - $start;
+		StatsD::timing("api.globalitems", $time * 1000);
+		
+		$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+		
+		if ($code != 200) {
+			$response = null;
+			Z_Core::logError("HTTP $code from Global Items API $requestURL");
+			Z_Core::logError($response);
+			return false;
+		}
+		
+		return $response;
+	}
+	
+	public static function getGlobalItemLibraryItems($id) {
+		$params = [];
+		
+		if (strpos($id, 'doi') === 0) {
+			$params['doi'] = $id;
+		}
+		else if (strpos($id, 'isbn') === 0) {
+			$params['isbn'] = $id;
+		}
+		else {
+			return [];
+		}
+		
+		$json = self::getGlobalItems($params);
+		$json = json_decode($json);
+		$libraryItems = $json[0]->libraryItems;
+		$groupedLibraryItems = [];
+		for ($i = 0, $len = sizeOf($libraryItems); $i < $len; $i++) {
+			$url = $libraryItems[$i];
+			$parts = explode('/', $url);
+			
+			$libraryID = null;
+			if ($parts[3] == 'users') {
+				$libraryID = Zotero_Users::getLibraryIDFromUserID($parts[4]);
+			}
+			else if ($parts[3] == 'groups') {
+				$libraryID = Zotero_Groups::getLibraryIDFromGroupID($parts[4]);
+			}
+			
+			$groupedLibraryItems[$libraryID][] = $parts[6];
+		}
+		return $groupedLibraryItems;
+	}
+}

--- a/model/Items.inc.php
+++ b/model/Items.inc.php
@@ -69,7 +69,7 @@ class Zotero_Items {
 		$shardID = Zotero_Shards::getByLibraryID($libraryID);
 		
 		$isPublications = !empty($params['publications']);
-		if ($params['publications'] && Zotero_Libraries::getType($libraryID) == 'publications') {
+		if ($isPublications && Zotero_Libraries::getType($libraryID) == 'publications') {
 			$isPublications = false;
 		}
 		


### PR DESCRIPTION
Added a minimal Global Items API support for dataserver. Searches only through the query parameter ('?q=') that searches in all fields. Also supports 'start' and 'limit' parameters.

There are much more parameters that can be added to the request. We have to decide which parameters will be accessible through dataserver.

