### PR TITLE
Allow RequestLimiter to work in Redis cluster mode

### DIFF
--- a/include/RequestLimiter.inc.php
+++ b/include/RequestLimiter.inc.php
@@ -16,7 +16,7 @@
 */
 
 class Z_RequestLimiter {
-	// If using Redis in cluster mode, '{the_same_value_to_hash}' must
+	// If using Redis in cluster mode, '{hash_key}' must
 	// be added to all keys to always hash to the same slot.
 	// The value can be anywhere in the key.
 	// More information: https://redis.io/topics/cluster-spec#keys-hash-tags

--- a/include/RequestLimiter.inc.php
+++ b/include/RequestLimiter.inc.php
@@ -16,7 +16,11 @@
 */
 
 class Z_RequestLimiter {
-	const REDIS_PREFIX = '';
+	// If using Redis in cluster mode, '{the_same_value_to_hash}' must
+	// be added to all keys to always hash to the same slot.
+	// The value can be anywhere in the key.
+	// More information: https://redis.io/topics/cluster-spec#keys-hash-tags
+	const REDIS_PREFIX = '{1}';
 	// Lua script is from https://gist.github.com/ptarjan/e38f45f2dfe601419ca3af937fff574d
 	const RATE_LIMITER_LUA = '
 		local tokens_key = KEYS[1]


### PR DESCRIPTION
If using Redis in cluster mode, '{the_same_value_to_hash}' must be added to all keys to always hash to the same slot. The value can be anywhere in the key. More information: https://redis.io/topics/cluster-spec#keys-hash-tags