### PR TITLE
Add a cluster configuration option for Redis

### DIFF
--- a/include/Redis.inc.php
+++ b/include/Redis.inc.php
@@ -11,41 +11,62 @@ class Z_Redis {
 			return self::$links[$name];
 		}
 		
-		if (!isset(Z_CONFIG::$REDIS_HOSTS)) {
-			Z_Core::logError('Warning: $REDIS_HOSTS is not set');
+		if (!isset(Z_CONFIG::$REDIS_CONFIG)) {
+			Z_Core::logError('Warning: $REDIS_CONFIG is not set');
 			return null;
 		}
 		
-		if (!isset(Z_CONFIG::$REDIS_HOSTS[$name])) {
+		if (!isset(Z_CONFIG::$REDIS_CONFIG[$name])) {
 			return null;
 		}
 		
-		// Host format can be "host" or "host:port"
-		$parts = explode(':', Z_CONFIG::$REDIS_HOSTS[$name]);
-		$host = $parts[0];
-		$port = isset($parts[1]) ? $parts[1] : 6379;
-		// Set up new phpredis instance for this host
-		$redis = new Redis();
+		// Set up new phpredis instance
 		try {
-			// 1s connection timeout, 100ms retry interval
-			if (!$redis->pconnect($host, $port, 1, NULL, 100)) {
-				throw new Exception("Redis connection to {$host}:{$port} failed");
+			$redis = null;
+			if (isset(Z_CONFIG::$REDIS_CONFIG[$name]['cluster']) &&
+				Z_CONFIG::$REDIS_CONFIG[$name]['cluster']) {
+				// Create cluster with 1s timeout and persistent connection
+				$redis = new RedisCluster(
+					NULL,
+					[Z_CONFIG::$REDIS_CONFIG[$name]['host']],
+					1,
+					1,
+					true
+				);
+				
+				$redis->setOption(RedisCluster::OPT_SERIALIZER, RedisCluster::SERIALIZER_NONE);
+				
+				if (!empty(Z_CONFIG::$REDIS_PREFIX)) {
+					$redis->setOption(RedisCluster::OPT_PREFIX, Z_CONFIG::$REDIS_PREFIX);
+				}
 			}
-			
-			// 1s read timeout
-			$redis->setOption(Redis::OPT_READ_TIMEOUT, 1);
-			// No serializer for now, because it's difficult to
-			// deserialize in other environments
-			$redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE);
-			if (!empty(Z_CONFIG::$REDIS_PREFIX)) {
-				$redis->setOption(Redis::OPT_PREFIX, Z_CONFIG::$REDIS_PREFIX);
+			else {
+				// Host format can be "host" or "host:port"
+				$parts = explode(':', Z_CONFIG::$REDIS_CONFIG[$name]['host']);
+				$host = $parts[0];
+				$port = isset($parts[1]) ? $parts[1] : 6379;
+				
+				$redis = new Redis();
+				// 1s connection timeout, 100ms retry interval
+				if (!$redis->pconnect($host, $port, 1, NULL, 100)) {
+					throw new Exception("Redis connection to {$host}:{$port} failed");
+				}
+				
+				// 1s read timeout
+				$redis->setOption(Redis::OPT_READ_TIMEOUT, 1);
+				// No serializer for now, because it's difficult to
+				// deserialize in other environments
+				$redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE);
+				if (!empty(Z_CONFIG::$REDIS_PREFIX)) {
+					$redis->setOption(Redis::OPT_PREFIX, Z_CONFIG::$REDIS_PREFIX);
+				}
 			}
+			return self::$links[$name] = $redis;
 		}
 		catch (Exception $e) {
 			Z_Core::logError($e);
 			// Cache connection failure
 			return self::$links[$name] = null;
 		}
-		return self::$links[$name] = $redis;
 	}
 }

--- a/include/config/config.inc.php-sample
+++ b/include/config/config.inc.php-sample
@@ -27,12 +27,22 @@ class Z_CONFIG {
 	public static $S3_BUCKET_CACHE = '';
 	public static $S3_BUCKET_FULLTEXT = '';
 
-	public static $REDIS_HOSTS = [
-		'default' => 'redis1.localdomain',
-		'request-limiter' => => 'redis-transient.localdomain',
-		'notifications' => 'redis-transient.localdomain'
-		'fulltext-migration' => 'redis-transient.localdomain'
+	public static $REDIS_CONFIG = [
+		'default' => [
+			'host' => 'redis1.localdomain'
+		],
+		'request-limiter' => [
+			'host' => 'redis-transient.localdomain'
+		],
+		'notifications' => [
+			'host' => 'redis-transient.localdomain'
+		],
+		'fulltext-migration' => [
+			'host' => 'redis-transient.localdomain',
+			'cluster' => true
+		]
 	];
+
 	public static $REDIS_PREFIX = '';
 	
 	public static $MEMCACHED_ENABLED = true;


### PR DESCRIPTION
Added Redis cluster support. Now Redis instances can have richer config options, because `host` alone isn't enough. `config.inc.php` file must be updated.