### PR TITLE
Feed items to SQS queue

### DIFF
--- a/include/SQS.inc.php
+++ b/include/SQS.inc.php
@@ -102,7 +102,7 @@ class Z_SQS {
 	
 	private static function load() {
 		if (!self::$sqs) {
-			self::$sqs = Z_Core::$AWS->get('sqs');
+			self::$sqs = Z_Core::$AWS->createSqs();
 		}
 	}
 }

--- a/include/config/config.inc.php-sample
+++ b/include/config/config.inc.php-sample
@@ -59,7 +59,9 @@ class Z_CONFIG {
 	);
 	
 	public static $SEARCH_HOSTS = [''];
-	
+
+	public static $ITEM_FEEDER_QUEUE = '';
+
 	public static $GLOBAL_ITEMS_URL = '';
 
 	public static $ATTACHMENT_SERVER_HOSTS = array("files1.localdomain", "files2.localdomain");

--- a/include/header.inc.php
+++ b/include/header.inc.php
@@ -194,6 +194,7 @@ Zotero_DB::addCallback("begin", array("Zotero_Notifier", "begin"));
 Zotero_DB::addCallback("commit", array("Zotero_Notifier", "commit"));
 Zotero_DB::addCallback("callback", array("Zotero_Notifier", "reset"));
 Zotero_NotifierObserver::init();
+Zotero_ItemFeederObserver::init();
 
 // Memcached
 require('Memcached.inc.php');

--- a/model/DataObjects.inc.php
+++ b/model/DataObjects.inc.php
@@ -661,6 +661,19 @@ trait Zotero_DataObjects {
 			}
 		}
 		
+		if ($deleted && $type == 'item') {
+			Zotero_Notifier::trigger(
+				'delete',
+				'item',
+				$libraryID . "/" . $key,
+				[
+					$libraryID . "/" . $key => [
+						'version' => $obj->version
+					]
+				]
+			);
+		}
+		
 		self::unload($obj->id);
 		
 		if ($deleted) {

--- a/model/ItemFeederObserver.inc.php
+++ b/model/ItemFeederObserver.inc.php
@@ -1,0 +1,148 @@
+<?php
+/*
+    ***** BEGIN LICENSE BLOCK *****
+    
+    This file is part of the Zotero Data Server.
+    
+    Copyright © 2013 Center for History and New Media
+                     George Mason University, Fairfax, Virginia, USA
+                     http://zotero.org
+    
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    
+    ***** END LICENSE BLOCK *****
+*/
+
+class Zotero_ItemFeederObserver {
+	// SQS has maximum message size of 262144 bytes
+	const MAX_JSON_SIZE = 250 * 1024;
+	
+	public static function init() {
+		Zotero_Notifier::registerObserver(
+			__CLASS__,
+			["item"],
+			"ItemFeederObserver"
+		);
+	}
+	
+	public static function notify($event, $type, $ids, $extraData) {
+		if ($type != "item") return;
+		$batch = [];
+		foreach ($ids as $id) {
+			$data = $extraData[$id];
+			if ($event == 'add') {
+				list($libraryID, $key) = explode("/", $id);
+				$item = Zotero_Items::getByLibraryAndKey($libraryID, $key);
+				$arr = [
+					'action' => 'add',
+					'id' => $id,
+					'version' => $item->version,
+					'item' => $item->toJSON(true)
+				];
+			}
+			else if ($event == 'modify') {
+				list($libraryID, $key) = explode("/", $id);
+				$item = Zotero_Items::getByLibraryAndKey($libraryID, $key);
+				$arr = [
+					'action' => 'modify',
+					'id' => $id,
+					'version' => $item->version,
+					'item' => $item->toJSON(true)
+				];
+			}
+			else if ($event == 'delete') {
+				$arr = [
+					'action' => 'delete',
+					'id' => $id,
+					'version' => $data['version']
+				];
+			}
+			
+			$json = self::formatLimitedSizeJSON($arr);
+			if ($json) {
+				$batch[] = $json;
+			}
+			else {
+				Z_Core::logError("Failed to limit JSON size for $id");
+			}
+			
+			// SQS accepts up to 10 messages per batch
+			if (count($batch) == 10) {
+				self::send($batch);
+				$batch = [];
+			}
+		}
+		
+		if (count($batch)) {
+			self::send($batch);
+		}
+	}
+	
+	private static function send($batch) {
+		$result = Z_SQS::sendBatch(Z_CONFIG::$ITEM_FEEDER_QUEUE, $batch);
+		$failedMessages = $result['Failed'];
+		if ($failedMessages) {
+			foreach ($failedMessages as $failedMessage) {
+				Z_Core::logError('Failed to send message to SQS: '
+					. $failedMessage['Message']);
+			}
+		}
+	}
+	
+	/**
+	 * Format JSON and limit its size by emptying its biggest string values
+	 * @param $arr
+	 * @return null|string
+	 */
+	private static function formatLimitedSizeJSON($arr) {
+		$json = json_encode($arr, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+		
+		$retries_left = 10;
+		while (strlen($json) > self::MAX_JSON_SIZE) {
+			if (!$retries_left) return null;
+			$retries_left--;
+			$biggest =& self::getBiggestString($arr);
+			if (!$biggest) return null;
+			$biggest = 'VALUE TOO BIG!';
+			$json = json_encode($arr, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+		}
+		return $json;
+	}
+	
+	/**
+	 * Get a reference to the biggest string value
+	 *
+	 * @param $arr
+	 * @return null|&string
+	 */
+	private static function &getBiggestString(&$arr) {
+		$biggest = null;
+		foreach ($arr as $key => &$value) {
+			if (is_array($value)) {
+				$biggest_child =& self::getBiggestString($value);
+				if ($biggest_child) {
+					if (!$biggest || strlen($biggest_child) > strlen($biggest)) {
+						$biggest = &$biggest_child;
+					}
+				}
+			}
+			else if (is_string($value)) {
+				if (!$biggest || strlen($value) > strlen($biggest)) {
+					$biggest = &$value;
+				}
+			}
+		}
+		return $biggest;
+	}
+}


### PR DESCRIPTION
The item feeder consists of this PR and [Lambda function](https://github.com/mrtcode/item-feeder).

There're some things to discuss, so I'm writing everything here.

Generally, the main idea is that deleted items must be flagged and kept in ES index for a while, because, otherwise they can be unexpectedly recreated by out of order and concurrent item operations.

The item feeding system is currently designed to use a standard (not FIFO guaranteed) SQS queue, but even though it would be a FIFO guaranteed queue, it won't solve the out of order index/delete messages problem. Because there is no guarantee that messages from dataserver will reach SQS in the right order, nor there is a guarantee that Lambda functions will consume messages in the right order.

Disordered `add` or `modify` messages, doesn't matter, but if mixed with a disordered `delete` message, deletion can happen (and fail) before creation, which results to a still existing item.

Although there's an ES built-in mechanism that could help, it actually doesn't fit in our case.
It works like this: when a document is deleted, its version is automatically incremented, no matter if internal or external versioning is used. The document id and version still exists for as long as `index.gc_deletes` is configured, and can be used to do version checks when indexing an item with the same id. Defaults to 60s.

Here are various examples explaining various situations when an item is deleted or operations are out of order:

```
Example 1:
{index: {_index: 'idx',_type:'tp',_id:'1/WCBVNWB9',_version:6,_version_type:'external_gt'}} Item indexed with version=6
{delete: {_index:'idx',_type:'tp',_id:'1/WCBVNWB9',_version:6}} Item is deleted but its id and version=7 internally still exists for 60s


Example 2:
{index: {_index: 'idx',_type:'tp',_id:'1/WCBVNWB9',_version:6,_version_type:'external_gt'}} Item indexed with version=6
{delete: {_index:'idx',_type:'tp',_id:'1/WCBVNWB9',_version:6}} Item is deleted. Id and version stays for 60s. version=7
{index: {_index: 'idx',_type:'tp',_id:'1/WCBVNWB9',_version:7,_version_type:'external_gt'}} Item fails if less than 60s passed, otherwise succeeds.


Example 3:
{index: {_index: 'idx',_type:'tp',_id:'1/WCBVNWB9',_version:6,_version_type:'external_gt'}} Item indexed with version=6
{delete: {_index:'idx',_type:'tp',_id:'1/WCBVNWB9',_version:6}} Item is deleted. Id and version stays for 60s. version=7
{index: {_index: 'idx',_type:'tp',_id:'1/WCBVNWB9',_version:8,_version_type:'external_gt'}} Indexing succeeds because 7<8


Example 4 (out of order operations, deletion comes before update, item exists even though it was deleted):
{index: {_index: 'idx',_type:'tp',_id:'1/WCBVNWB9',_version:5,_version_type:'external_gt'}} Item indexed with version=5
{delete: {_index:'idx',_type:'tp',_id:'1/WCBVNWB9',_version:6}} Deletion fails, because version doesn't match
{index: {_index: 'idx',_type:'tp',_id:'1/WCBVNWB9',_version:6,_version_type:'external_gt'}} Succeeds because 5<6


Example 5 (out of order operations, deletion comes before creation, item exists even though it was deleted):
{delete: {_index:'idx',_type:'tp',_id:'1/WCBVNWB9',_version:3}} Deletion fails, because nor document nor version exists
{index: {_index: 'idx',_type:'tp',_id:'1/WCBVNWB9',_version:1,_version_type:'external_gt'}} Item is indexed
{index: {_index: 'idx',_type:'tp',_id:'1/WCBVNWB9',_version:2,_version_type:'external_gt'}} Item is indexed
```

So the idea is that when dataserver deletes an item, ES, instead of deleting it too, must index its id, version, deletion flag, and the time when it was deleted. After a safe time period those items can be automatically deleted from ES.
