### PR TITLE
Avoid returning signed URL that is close to expiry

### DIFF
--- a/model/Attachments.inc.php
+++ b/model/Attachments.inc.php
@@ -89,7 +89,7 @@ class Zotero_Attachments {
 		}
 		
 		$url = self::generateSignedURL($payload, $filename);
-		Z_Core::$MC->set($cacheKey, $url, self::$urlTTL - 5);
+		Z_Core::$MC->set($cacheKey, $url, self::$urlTTL - 15);
 		return $url;
 	}
 	


### PR DESCRIPTION
Reduces longevity of the cache entry for a signed URL by 5 seconds. Previously a link would be cached for as long as it's valid, meaning that an edge case is possible where a URL expires by the time it is transmitted to the API user. After this change, in a worst-case-scenario, the URL is valid for another 5 seconds (at the time request is processed) leaving enough time for network transfer.

While this is specifically needed for Web Library (see zotero/web-library#451, zotero/web-library#452), I think it's a good idea to avoid sending a URL that are on the verge of expiring.