### PR TITLE
NotifierObserver sets continued=false for the last message to be sent

### DIFF
--- a/model/NotifierObserver.inc.php
+++ b/model/NotifierObserver.inc.php
@@ -56,6 +56,8 @@ class Zotero_NotifierObserver {
 	
 	
 	public static function notify($event, $type, $ids, $extraData) {
+		$index = 0;
+		$last_index = count($ids) - 1;
 		if ($type == "library" || $type == "publications") {
 			switch ($event) {
 			case "modify":
@@ -69,7 +71,6 @@ class Zotero_NotifierObserver {
 			default:
 				return;
 			}
-			
 			foreach ($ids as $id) {
 				$libraryID = $id;
 				// For most libraries, get topic from URI
@@ -102,7 +103,8 @@ class Zotero_NotifierObserver {
 				];
 				
 				if (self::$continued) {
-					$message['continued'] = true;
+					//Set continued=false for the last item
+					$message['continued'] = ($index != $last_index);
 				}
 				
 				if (!empty($extraData[$id])) {
@@ -110,6 +112,7 @@ class Zotero_NotifierObserver {
 						$message[$key] = $val;
 					}
 				}
+				$index++;
 				self::send($topic, $message);
 			}
 		}
@@ -140,7 +143,8 @@ class Zotero_NotifierObserver {
 				];
 				
 				if (self::$continued) {
-					$message['continued'] = true;
+					//Set continued=false for the last item
+					$message['continued'] = ($index != $last_index);
 				}
 				
 				if (!empty($extraData[$id])) {
@@ -148,7 +152,7 @@ class Zotero_NotifierObserver {
 						$message[$key] = $val;
 					}
 				}
-				
+				$index++;
 				self::send("api-key:$apiKeyID", $message);
 			}
 		}


### PR DESCRIPTION
Addresses [Issue #130](https://github.com/zotero/dataserver/issues/130)

While looping through the messages to send,` NotifiedObserver.notify ` keeps track of the id of the message being sent out, and sets `$message['continued']=false` when the last message from array is reached