### PR TITLE
404 instead of 500 error on bad groupID or userID

### DIFF
--- a/controllers/ItemsController.php
+++ b/controllers/ItemsController.php
@@ -269,6 +269,10 @@ class ItemsController extends ApiController {
 		else {
 			$this->allowMethods(array('HEAD', 'GET', 'POST', 'DELETE'));
 			
+			if (!$this->objectLibraryID){
+				$this->e404();
+			}
+			
 			// Check for general library access
 			if (!$this->publications && !$this->permissions->canAccess($this->objectLibraryID)) {
 				$this->e403();


### PR DESCRIPTION
Applies to endpoints like /groups/BAD_NAME/items or /users/BAD_NAME/items

Fixes: #96