### PR TITLE
creator as non-classic data object

### DIFF
--- a/misc/db-updates/2023-07-17/classic_data_objects.sql
+++ b/misc/db-updates/2023-07-17/classic_data_objects.sql
@@ -1,0 +1,14 @@
+alter table itemCreators drop constraint itemCreators_ibfk_2;
+DROP table creators;
+
+DROP trigger if exists fki_itemCreators_libraryID;
+DROP trigger if exists fku_itemCreators_libraryID;
+
+CREATE TABLE `creators` (
+  `creatorID` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `firstName` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `lastName` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `fieldMode` tinyint(1) unsigned DEFAULT NULL,
+  PRIMARY KEY (`creatorID`),
+  KEY `name` (`lastName`(7),`firstName`(6))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/misc/master.sql
+++ b/misc/master.sql
@@ -184,6 +184,7 @@ CREATE TABLE `libraries` (
   `lastUpdated` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
   `version` int(10) unsigned NOT NULL DEFAULT '0',
   `shardID` smallint(5) unsigned NOT NULL,
+  `hasData` TINYINT( 1 ) NOT NULL DEFAULT '0',
   PRIMARY KEY (`libraryID`),
   KEY `shardID` (`shardID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/misc/shard.sql
+++ b/misc/shard.sql
@@ -330,7 +330,7 @@ CREATE TABLE `syncDeleteLogIDs` (
 
 CREATE TABLE `syncDeleteLogKeys` (
   `libraryID` int(10) unsigned NOT NULL,
-  `objectType` enum('collection','creator','item','relation','search','setting','tag','tagName') NOT NULL,
+  `objectType` enum('collection','item','relation','search','setting','tag','tagName') NOT NULL,
   `key` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
   `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `version` int(10) unsigned NOT NULL DEFAULT '1',

--- a/model/Items.inc.php
+++ b/model/Items.inc.php
@@ -1749,26 +1749,17 @@ class Zotero_Items {
 						}
 						
 						// Make a fake creator to use for the data lookup
-						$newCreator = new Zotero_Creator;
-						$newCreator->libraryID = $item->libraryID;
-						foreach ($newCreatorData as $key=>$val) {
-							if ($key == 'creatorType') {
-								continue;
-							}
-							$newCreator->$key = $val;
-						}
-						
+						$newCreator = new Zotero_Creator(null, $item->libraryID, $newCreatorData->firstName, $newCreatorData->lastName, $newCreatorData->fieldMode);
+
 						// Look for an equivalent creator in this library
 						$candidates = Zotero_Creators::getCreatorsWithData($item->libraryID, $newCreator, true);
 						if ($candidates) {
-							$c = Zotero_Creators::get($item->libraryID, $candidates[0]);
-							$item->setCreator($orderIndex, $c, $newCreatorTypeID);
+							$item->setCreator($orderIndex, $candidates[0], $newCreatorTypeID);
 							continue;
 						}
 						
 						// None found, so make a new one
-						$creatorID = $newCreator->save();
-						$newCreator = Zotero_Creators::get($item->libraryID, $creatorID);
+						$newCreator->save();
 						$item->setCreator($orderIndex, $newCreator, $newCreatorTypeID);
 					}
 					


### PR DESCRIPTION
- Removed ClassicDataObject as a parent class of Zotero_Creators
- Removed all `load()`-ing of Zotero_Creators. An object is constructed with data right away. 
- One `join` in `loadCreators` to load all creators on GET requests, instead of sequential `$item->load()`.
- Some minor refactoring to try to avoid extra queries