### PR TITLE
use === only for non-objects in settings model

### DIFF
--- a/model/Setting.inc.php
+++ b/model/Setting.inc.php
@@ -73,7 +73,11 @@ class Zotero_Setting {
 		
 		$this->checkProperty($prop, $value);
 		
-		if ($this->$prop != $value) {
+		// If the existing field is an object or an array (e.g. [{"name", "value"}] for tagColors),
+		// use == operator to check if all fields within the arrays/objects match. 
+		// Otherwise, use === so that if $this->$prop is null and $value is 0, they do not count as equal.
+		$isObjectOrArray = is_array($this->$prop) || is_object($this->$prop);
+		if (($isObjectOrArray && $this->$prop != $value) || (!$isObjectOrArray && $this->$prop !== $value)) {
 			//Z_Core::debug("Setting property '$prop' has changed from '{$this->$prop}' to '$value'");
 			$this->changed = true;
 			$this->$prop = $value;


### PR DESCRIPTION
When comparing if a new value is different from the existing value of a setting, use == comparison for objects or arrays and === for everything else.

=== ensures that if existing value is null,  it does not count as equal to 0.
== ensures that objects and arrays have their actual fields compared.