### PR TITLE
Add `mendeleyDB:notebookUUID` as allowed relation predicate

### DIFF
--- a/model/Relations.inc.php
+++ b/model/Relations.inc.php
@@ -40,7 +40,8 @@ class Zotero_Relations extends Zotero_ClassicDataObjects {
 		'mendeleyDB:annotationUUID',
 		'mendeleyDB:relatedDocumentUUID',
 		'mendeleyDB:relatedRemoteDocumentUUID',
-		'mendeleyDB:relatedFileHash'
+		'mendeleyDB:relatedFileHash',
+		'mendeleyDB:notebookUUID'
 	];
 	
 	public static $externalPredicates = [
@@ -51,7 +52,8 @@ class Zotero_Relations extends Zotero_ClassicDataObjects {
 		'mendeleyDB:remoteFolderUUID',
 		'mendeleyDB:relatedDocumentUUID',
 		'mendeleyDB:relatedRemoteDocumentUUID',
-		'mendeleyDB:relatedFileHash'
+		'mendeleyDB:relatedFileHash',
+		'mendeleyDB:notebookUUID'
 	];
 	
 	protected static $ZDO_object = 'relation';


### PR DESCRIPTION
zotero/zotero#4829 introduced a new relation `mendeleyDB:notebookUUID` but it's currently rejected by the data server. This PR should fix it, though I didn't test if it works.