### PR TITLE
Allow synced settings for file renaming

### DIFF
--- a/model/Settings.inc.php
+++ b/model/Settings.inc.php
@@ -28,6 +28,9 @@ class Zotero_Settings extends Zotero_ClassicDataObjects {
 	public static $MAX_VALUE_LENGTH = 30000;
 	
 	public static $allowedSettings = [
+		'attachmentRenameTemplate',
+		'autoRenameFiles',
+		'autoRenameFilesFileTypes',
 		'feeds',
 		'tagColors',
 		'/^lastPageIndex_(u|g[0-9]+)_[A-Z0-9]{8}$/',
@@ -219,6 +222,7 @@ class Zotero_Settings extends Zotero_ClassicDataObjects {
 			break;
 		
 		// Array settings
+		case 'autoRenameFilesFileTypes':
 		case 'readerCustomThemes':
 		case 'tagColors':
 			if (!is_array($value)) {

--- a/model/Settings.inc.php
+++ b/model/Settings.inc.php
@@ -241,6 +241,13 @@ class Zotero_Settings extends Zotero_ClassicDataObjects {
 			}
 			break;
 		
+		// Boolean settings
+		case 'autoRenameFiles':
+			if (!is_bool($value)) {
+				throw new Exception("'value' must be a boolean", Z_ERROR_INVALID_INPUT);
+			}
+			break;
+		
 		case 'lastPageIndex':
 			if (!is_integer($value) && !is_string($value) && !is_float($value)) {
 				throw new Exception("'value' must be an integer, string, or decimal", Z_ERROR_INVALID_INPUT);


### PR DESCRIPTION
This PR allows three more setting keys required for zotero/zotero#3860:

The plan is for the `attachmentRenameTemplate` to be used in both the user's and group libraries, while `autoRenameFiles` and `autoRenameFilesFileTypes` will be used for group libraries only.

There are no other boolean-type synced settings. Not sure if we want to treat `autoRenameFiles` as a `true`/`false` string or as a `0`/`1` integer?