### PR TITLE
Remove bidirectional nature of related items

### DIFF
--- a/model/Item.inc.php
+++ b/model/Item.inc.php
@@ -5020,18 +5020,6 @@ class Zotero_Item extends Zotero_DataObject {
 			return [$rel->predicate, $rel->object];
 		}, $relations);
 		
-		// Related items are bidirectional, so include any with this item as the object
-		$reverseRelations = Zotero_Relations::getByURIs(
-			$this->libraryID, false, Zotero_Relations::$relatedItemPredicate, $itemURI
-		);
-		foreach ($reverseRelations as $rel) {
-			$r = [$rel->predicate, $rel->subject];
-			// Only add if not already added in other direction
-			if (!in_array($r, $relations)) {
-				$relations[] = $r;
-			}
-		}
-		
 		// Also include any owl:sameAs relations with this item as the object
 		// (as sent by client via classic sync)
 		$reverseRelations = Zotero_Relations::getByURIs(
@@ -5052,18 +5040,6 @@ class Zotero_Item extends Zotero_DataObject {
 			$prefix = Zotero_URI::getLibraryURI($this->libraryID) . "/items/";
 			$predicate = Zotero_Relations::$relatedItemPredicate;
 			foreach ($relatedItemKeys as $key) {
-				$relations[] = [$predicate, $prefix . $key];
-			}
-		}
-		// Reverse as well
-		$sql = "SELECT `key` FROM itemRelated IR JOIN items I USING (itemID) WHERE IR.linkedItemID=?";
-		$reverseRelatedItemKeys = Zotero_DB::columnQuery(
-			$sql, $this->id, Zotero_Shards::getByLibraryID($this->libraryID)
-		);
-		if ($reverseRelatedItemKeys) {
-			$prefix = Zotero_URI::getLibraryURI($this->libraryID) . "/items/";
-			$predicate = Zotero_Relations::$relatedItemPredicate;
-			foreach ($reverseRelatedItemKeys as $key) {
 				$relations[] = [$predicate, $prefix . $key];
 			}
 		}


### PR DESCRIPTION
Related items have been treated as bidirectional after https://github.com/zotero/dataserver/commit/fbaa602bdd32b0f43b8997f51aa13686986eab01. This means that if item A is one of related items for item B but not the other way around, item B would still be included in the list of related items for item A.

This caused sync issue when one of two related items was deleted. Modifications to the non-deleted item are synced first, followed by the deletion.
The dataserver would return the relation to the item that was about to be deleted after modification of the non-deleted item is handled. This would trick Zotero on the client side into believing that the relation to the deleted item still existed.

More context: https://github.com/zotero/zotero/pull/5486