### PR TITLE
Expose zip file metadata for attachments where it's relevant

### DIFF
--- a/model/Item.inc.php
+++ b/model/Item.inc.php
@@ -4146,6 +4146,9 @@ class Zotero_Item extends Zotero_DataObject {
 				// Link to publications download URL in My Publications
 				if ($downloadDetails && $requestParams['publications']) {
 					$downloadDetails['url'] = str_replace("/items/", "/publications/items/", $downloadDetails['url']);
+					if (!empty($downloadDetails['zip'])) {
+						$downloadDetails['zip']['url'] = str_replace("/items/", "/publications/items/", $downloadDetails['zip']['url']);
+					}
 				}
 			}
 		}
@@ -4196,7 +4199,7 @@ class Zotero_Item extends Zotero_DataObject {
 			$requestParams['schemaVersion'] ?? null
 		);
 
-		$cacheVersion = 8;
+		$cacheVersion = 9;
 		$cacheKey = "jsonEntry_" . $this->libraryID . "/" . $this->id . "_"
 			. md5(
 				$version
@@ -4348,6 +4351,15 @@ class Zotero_Item extends Zotero_DataObject {
 			}
 			if (isset($details['size'])) {
 				$json['links']['enclosure']['length'] = $details['size'];
+			}
+			if (!empty($details['zip'])) {
+				$json['links']['zip'] = [
+					'type' => 'application/zip',
+					'href' => $details['zip']['url'],
+					'title' => $details['zip']['filename'],
+					'length' => (int) $details['zip']['size'],
+					'md5' => $details['zip']['md5'],
+				];
 			}
 		}
 		

--- a/model/Items.inc.php
+++ b/model/Items.inc.php
@@ -1181,6 +1181,14 @@ class Zotero_Items {
 			if (isset($details['size'])) {
 				$link['length'] = $details['size'];
 			}
+			if (!empty($details['zip'])) {
+				$link = $xml->addChild('link');
+				$link['rel'] = 'zip';
+				$link['type'] = 'application/zip';
+				$link['href'] = $details['zip']['url'];
+				$link['title'] = $details['zip']['filename'];
+				$link['length'] = $details['zip']['size'];
+			}
 		}
 		
 		$xml->addChild('zapi:key', $item->key, Zotero_Atom::$nsZoteroAPI);

--- a/model/Storage.inc.php
+++ b/model/Storage.inc.php
@@ -46,8 +46,17 @@ class Zotero_Storage {
 		$url = Zotero_API::getItemURI($item) . "/file/view";
 		$info = self::getFileInfoByID($storageFileID);
 		if ($info['zip']) {
+			// Top-level 'filename'/'size' are omitted because 'links.enclosure' points
+			// at /file/view (viewer output, dynamic length).
+			// Wrapper identifiers go under 'zip' for the sibling 'links.zip' link.
 			return array(
-				'url' => $url
+				'url' => $url,
+				'zip' => array(
+					'url' => Zotero_API::getItemURI($item) . "/file",
+					'filename' => $info['filename'],
+					'size' => $info['size'],
+					'md5' => $info['hash']
+				)
 			);
 		}
 		else {

--- a/tests/remote-php/tests/API/3/FileTest.php
+++ b/tests/remote-php/tests/API/3/FileTest.php
@@ -1220,9 +1220,23 @@ class FileTests extends APITests {
 		$this->assert200($response);
 		// S3 should return ZIP content type
 		$this->assertEquals('application/zip', $response->getHeader("Content-Type"));
+
+		// Verify links.zip on the item JSON view
+		$response = API::userGet(self::$config['userID'], "items/$key");
+		$this->assert200($response);
+		$json = API::getJSONFromResponse($response);
+		$this->assertArrayHasKey('zip', $json['links']);
+		$this->assertEquals('application/zip', $json['links']['zip']['type']);
+		$this->assertEquals($zipFilename, $json['links']['zip']['title']);
+		$this->assertSame($zipSize, $json['links']['zip']['length']);
+		$this->assertEquals($zipHash, $json['links']['zip']['md5']);
+		$this->assertRegExp(
+			"%^https?://[^/]+/users/" . self::$config['userID'] . "/items/$key/file$%",
+			$json['links']['zip']['href']
+		);
 	}
-	
-	
+
+
 	public function test_should_reject_file_in_personal_library_if_it_would_put_user_over_quota() {
 		API::userClear(self::$config['userID']);
 		

--- a/tests/remote/tests/3/file.test.js
+++ b/tests/remote/tests/3/file.test.js
@@ -1074,6 +1074,20 @@ describe('File', function () {
 		assert200(response);
 		// S3 should return ZIP content type
 		assert.equal(response.getHeader('Content-Type'), 'application/zip');
+
+		// Verify links.zip on the item JSON view
+		response = await API.userGet(config.get('userID'), `items/${key}`);
+		assert200(response);
+		json = API.getJSONFromResponse(response);
+		assert.property(json.links, 'zip');
+		assert.equal(json.links.zip.type, 'application/zip');
+		assert.equal(json.links.zip.title, zipFilename);
+		assert.strictEqual(json.links.zip.length, zipSize);
+		assert.equal(json.links.zip.md5, zipHash);
+		assert.match(
+			json.links.zip.href,
+			new RegExp(`^https?://[^/]+/users/${config.get('userID')}/items/${key}/file$`)
+		);
 	});
 
 	// PHP: test_should_reject_file_in_personal_library_if_it_would_put_user_over_quota


### PR DESCRIPTION
This PR will expose the zip metadata as `links.zip` to allow web-library to copy and rename snapshot attachments (https://github.com/zotero/web-library/issues/657). It looks like this:
````
 "zip": {
                "type": "application/zip",
                "href": "<BASEURL>/groups/1/items/5IWPU6EA/file",
                "title": "3Z7Q4N6Q.zip",
                "length": 7825,
                "md5": "30beafba10cc25883d6e875dff6950d9"
            }
````
Without this change, the web library is unable to re-register a file copied to a group library. That's because the web library has no way to learn (nor calculate) the wrapper's MD5, filename, and byte size from the existing item JSON. The existing md5/filename describe the inner file, and `links.enclosure` only carries the proxy-view URL. We also need this to enable file renaming ability for snapshots in the web library (currently broken), albeit it will have to do a full zip-and-upload workflow.

The alternative would be to add more response headers to the CORS safe list in the `?info=1` response. However, that means that the web library has to run an extra request for every file it renames or copies. Since the data is already there, I've opted for an additional entry in `links` instead.

I've tested the changes locally. @dstillman  If you believe this should be done differently, please let me know!